### PR TITLE
fix: Header styling for trailing slash and logo size

### DIFF
--- a/portfolio/src/components/Header.tsx
+++ b/portfolio/src/components/Header.tsx
@@ -25,12 +25,15 @@ export default function Header() {
   const getLinkStyle = (href: string) => {
     let isActive = false;
     
+    // pathnameを正規化（末尾のスラッシュを削除）
+    const normalizedPathname = pathname?.replace(/\/$/, '') || '';
+    
     if (href === "/") {
       // Workリンクの場合、/（TOPページ）または/work/で始まるパスでアクティブ
-      isActive = pathname === "/" || (pathname ? pathname.startsWith("/work/") : false);
+      isActive = normalizedPathname === "" || normalizedPathname.startsWith("/work");
     } else {
-      // その他のリンクは完全一致
-      isActive = pathname === href;
+      // その他のリンクは完全一致（正規化後）
+      isActive = normalizedPathname === href;
     }
     
     return isActive 
@@ -41,7 +44,7 @@ export default function Header() {
   return (
     <header className="bg-[#4B3B39] text-white px-4 sm:px-12 py-4 flex items-center justify-between">
       <Link href="/" className="font-bold text-xl tracking-wide">
-        <Image src="/images/logo.png" alt="Logo" width={160} height={300} style={{width: "auto"}} />
+        <Image src="/images/logo.png" alt="Logo" width={160} height={300} style={{width: "160px", height: "auto"}} />
       </Link>
       <nav className="flex items-center gap-2 sm:gap-4">
         <Link href="/" className={getLinkStyle("/")}>Work</Link>


### PR DESCRIPTION
# Fix: Header styling for trailing slash and logo size

## Issue

The header displayed differently between the `feat/gh-pages-export` and `develop` branches:

1. **About page doesn't show active state**
   - When navigating to the About page, the "About" link in the navigation doesn't get a white background

2. **Logo size differs**
   - The logo image displays larger than intended

## Root Cause

### 1. Trailing Slash Mismatch

The `next.config.ts` includes `trailingSlash: true` for static export, which results in URLs like `/about/` (with trailing slash) after build. However, the active state logic in `Header.tsx` used strict equality (`pathname === href`), so `/about/` and `/about` didn't match, preventing the active state from being applied.

### 2. Image Optimization Disabled

Static export requires `images.unoptimized: true`, which disables Next.js image optimization. The original code used `style={{width: "auto"}}`, causing the original image size to be used in unoptimized environments, resulting in an oversized logo.

## Solution

### 1. Added pathname normalization

Added normalization logic in the `getLinkStyle` function to remove trailing slashes from pathname, ensuring correct behavior regardless of the `trailingSlash` setting.

```tsx
// Before
isActive = pathname === href;

// After
const normalizedPathname = pathname?.replace(/\/$/, '') || '';
isActive = normalizedPathname === href;
```

### 2. Explicit logo size specification

Changed to `style={{width: "160px", height: "auto"}}` to ensure consistent display size regardless of image optimization settings.

```tsx
// Before
<Image src="/images/logo.png" alt="Logo" width={160} height={300} style={{width: "auto"}} />

// After
<Image src="/images/logo.png" alt="Logo" width={160} height={300} style={{width: "160px", height: "auto"}} />
```

## Testing

- [ ] Verify behavior on `develop` branch
- [ ] Verify behavior on `feat/gh-pages-export` branch
- [ ] Confirm navigation active state displays correctly on all pages
- [ ] Confirm logo size is consistent across both branches