### PR TITLE
Release v0.1.1: Restrict GitHub Pages deploy to main branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,10 +2,13 @@
 name: GitHub Pages (Next.js export)
 
 on:
-  workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -38,6 +41,7 @@ jobs:
           path: portfolio/out
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
### What changed
- Updated workflow to run build on pull requests (no deployment)
- Restricted deployment to the main branch only
- Prevents PRs from overwriting the production site

### Why
To ensure preview builds run safely on PRs, while the production URL is only updated when changes are merged to main.